### PR TITLE
画像のファイル名をタイムスタンプにしてアップロードする

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,10 +15,11 @@ void setup()
   for (int i = 0; i < 10; i++)
   {
     time_t t = time(NULL);
-    tm *tm = localtime(&t);
-    Serial.printf("%04d-%02d-%02d %02d:%02d:%02d\n",
-                  tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
-                  tm->tm_hour, tm->tm_min, tm->tm_sec);
+
+    char buffer[256];
+    strftime(buffer, sizeof(buffer), "%F %T", localtime(&t));
+    Serial.println(buffer);
+
     delay(1000);
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,19 @@ void setup()
   Serial.setDebugOutput(true);
   Serial.println();
 
+  setupWiFi();
+
+  configTzTime("JST-9", "ntp.nict.jp", "ntp.jst.mfeed.ad.jp");
+  for (int i = 0; i < 10; i++)
+  {
+    time_t t = time(NULL);
+    tm *tm = localtime(&t);
+    Serial.printf("%04d-%02d-%02d %02d:%02d:%02d\n",
+                  tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+                  tm->tm_hour, tm->tm_min, tm->tm_sec);
+    delay(1000);
+  }
+
   camera_config_t cameraConfig = {
       .pin_pwdn = PWDN_GPIO_NUM,
       .pin_reset = RESET_GPIO_NUM,
@@ -44,7 +57,7 @@ void setup()
   }
 
   const auto *frameBuffer = esp_camera_fb_get();
-  upload(frameBuffer->buf, frameBuffer->len);
+  putImage(frameBuffer->buf, frameBuffer->len);
 }
 
 void loop()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,22 @@
 #include "camera_pins.h"
 #include "upload.h"
 
+String getTimestamp()
+{
+  configTzTime("JST-9", "ntp.nict.jp", "ntp.jst.mfeed.ad.jp");
+  delay(1000); // NTP による現在時刻取得が完了するのを待つ
+
+  const time_t t = time(NULL);
+  if (t < 1600000000) // 最近の時刻っぽい値にセットされたか確認
+  {
+    throw "Failed to sync current time";
+  }
+
+  char buffer[32];
+  strftime(buffer, sizeof(buffer), "%F %T", localtime(&t));
+  return String(buffer);
+}
+
 void setup()
 {
   Serial.begin(115200);
@@ -10,18 +26,8 @@ void setup()
   Serial.println();
 
   setupWiFi();
-
-  configTzTime("JST-9", "ntp.nict.jp", "ntp.jst.mfeed.ad.jp");
-  for (int i = 0; i < 10; i++)
-  {
-    time_t t = time(NULL);
-
-    char buffer[256];
-    strftime(buffer, sizeof(buffer), "%F %T", localtime(&t));
-    Serial.println(buffer);
-
-    delay(1000);
-  }
+  String timestamp = getTimestamp();
+  Serial.println(timestamp);
 
   camera_config_t cameraConfig = {
       .pin_pwdn = PWDN_GPIO_NUM,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,9 @@
 #include "camera_pins.h"
 #include "upload.h"
 
+/**
+ * 2021-05-29T13-16-07 のような形式のタイムスタンプ文字列を返す
+ */
 String getTimestamp()
 {
   configTzTime("JST-9", "ntp.nict.jp", "ntp.jst.mfeed.ad.jp");
@@ -15,7 +18,7 @@ String getTimestamp()
   }
 
   char buffer[32];
-  strftime(buffer, sizeof(buffer), "%F %T", localtime(&t));
+  strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H-%M-%S", localtime(&t));
   return String(buffer);
 }
 
@@ -26,8 +29,6 @@ void setup()
   Serial.println();
 
   setupWiFi();
-  String timestamp = getTimestamp();
-  Serial.println(timestamp);
 
   camera_config_t cameraConfig = {
       .pin_pwdn = PWDN_GPIO_NUM,
@@ -64,7 +65,8 @@ void setup()
   }
 
   const auto *frameBuffer = esp_camera_fb_get();
-  putImage(frameBuffer->buf, frameBuffer->len);
+  const auto filename = getTimestamp() + ".jpeg";
+  putImage(frameBuffer->buf, frameBuffer->len, filename);
 }
 
 void loop()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@ String getTimestamp()
   configTzTime("JST-9", "ntp.nict.jp", "ntp.jst.mfeed.ad.jp");
   delay(1000); // NTP による現在時刻取得が完了するのを待つ
 
-  const time_t t = time(NULL);
+  const auto t = time(NULL);
   if (t < 1600000000) // 最近の時刻っぽい値にセットされたか確認
   {
     throw "Failed to sync current time";
@@ -30,7 +30,7 @@ void setup()
 
   setupWiFi();
 
-  camera_config_t cameraConfig = {
+  const camera_config_t cameraConfig = {
       .pin_pwdn = PWDN_GPIO_NUM,
       .pin_reset = RESET_GPIO_NUM,
       .pin_xclk = XCLK_GPIO_NUM,
@@ -57,7 +57,7 @@ void setup()
       .fb_count = 2};
 
   // camera init
-  esp_err_t err = esp_camera_init(&cameraConfig);
+  const auto err = esp_camera_init(&cameraConfig);
   if (err != ESP_OK)
   {
     Serial.printf("Camera init failed with error 0x%x", err);

--- a/src/upload.cpp
+++ b/src/upload.cpp
@@ -74,9 +74,3 @@ void putImage(uint8_t *buffer, size_t length)
     https.end();
   }
 }
-
-void upload(uint8_t *buffer, size_t length)
-{
-  setupWiFi();
-  putImage(buffer, length);
-}

--- a/src/upload.cpp
+++ b/src/upload.cpp
@@ -42,7 +42,7 @@ void setupWiFi()
   Serial.println(WiFi.localIP());
 }
 
-void putImage(uint8_t *buffer, size_t length)
+void putImage(uint8_t *buffer, const size_t length, const String filename)
 {
   WiFiClientSecure wiFiClient;
   wiFiClient.setCACert(ROOT_CA);
@@ -51,8 +51,7 @@ void putImage(uint8_t *buffer, size_t length)
   {
     HTTPClient https;
 
-    const auto url = String(UPLOAD_URL) + "foo.jpeg";
-    if (!https.begin(wiFiClient, url))
+    if (!https.begin(wiFiClient, UPLOAD_URL + filename))
     {
       throw "Failed to connect to host";
     }
@@ -60,7 +59,7 @@ void putImage(uint8_t *buffer, size_t length)
     https.addHeader("X-Api-Key", UPLOAD_API_KEY);
     https.addHeader("Content-Type", "image/jpeg");
 
-    Serial.println("Uploading image... (" + String(length) + " bytes)");
+    Serial.println("Uploading " + filename + "... (" + String(length) + " bytes)");
     const int code = https.PUT(buffer, length);
     if (code < 0)
     {

--- a/src/upload.h
+++ b/src/upload.h
@@ -1,1 +1,2 @@
-void upload(uint8_t *buffer, size_t length);
+void setupWiFi();
+void putImage(uint8_t *buffer, size_t length);

--- a/src/upload.h
+++ b/src/upload.h
@@ -1,2 +1,2 @@
 void setupWiFi();
-void putImage(uint8_t *buffer, size_t length);
+void putImage(uint8_t *buffer, const size_t length, const String filename);


### PR DESCRIPTION
カメラで撮影した時刻（JST）を使って `2021-05-29T13-16-07.jpeg` のようなファイル名にする。

送信に数秒かかるので、S3 オブジェクトの最終更新日時とは若干ずれる。

![S3_Management_Console](https://user-images.githubusercontent.com/6268183/120057854-820aeb80-c081-11eb-9e9a-785f88925534.jpg)

先に NTP で時刻合わせを行っておく必要がある。

Close #5