### PR TITLE
撮影間隔のズレを軽減する

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,8 +4,8 @@
 
 // 撮影間隔 [ms]
 const int INTERVAL = 10 * 60 * 1000;
-// カメラ起動時後、ホワイトバランスが安定するまでに待つ時間 [s]
-const int CAMERA_WAIT = 20;
+// カメラ起動時後、ホワイトバランスが安定するまでに待つ時間 [ms]
+const int CAMERA_WAIT = 20 * 1000;
 
 // 最後に撮影・送信に成功した際の、撮影時刻の Unix time [ms]
 // deep sleep しても値は保持される
@@ -32,8 +32,8 @@ void deepSleep()
 
   Serial.println("Enter deep sleep mode.");
   // WiFi 接続や送信処理などにかかる時間と、RTC の誤差を吸収するための余裕時間
-  const int margin = 15; // [s]
-  ESP.deepSleep((INTERVAL - CAMERA_WAIT * 1000 - margin * 1000) * 1000);
+  const int margin = 15 * 1000; // [ms]
+  ESP.deepSleep((INTERVAL - CAMERA_WAIT - margin) * 1000);
   delay(1000); // deep sleep が始まるまで待つ
 }
 
@@ -84,7 +84,7 @@ void setupCamera()
   sensor->set_dcw(sensor, 0);
 
   // ホワイトバランスが安定するまで待つ
-  delay(CAMERA_WAIT * 1000);
+  delay(CAMERA_WAIT);
 
   Serial.println("Initialized.");
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,19 +13,14 @@ RTC_DATA_ATTR long long lastCapturedAt = 0;
 
 const int LED_BUILTIN = 4;
 
-// 現在の Unix time をミリ秒単位で返す
-const long long getCurrentMSec()
-{
-  struct timeval tv;
-  gettimeofday(&tv, NULL);
-  return tv.tv_sec * 1000LL + tv.tv_usec / 1000LL;
-}
-
 // 撮影間隔がちょうど INTERVAL [ms] になるように、delay を挟む
 // 戻り値は今回の撮影時刻
 const long long waitUntilNextCaptureTime(const long long lastCapturedAt)
 {
-  const auto now = getCurrentMSec();
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  const auto now = tv.tv_sec * 1000LL + tv.tv_usec / 1000LL; // 現在の Unix time [ms]
+
   if (!lastCapturedAt)
     return now; // 初回起動時は待ち時間なし
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,18 +105,19 @@ const camera_fb_t *captureImage(const long long lastCapturedAt)
   return image;
 }
 
-// 撮影時刻を Unix time [s] で返す
-const time_t getCapturedAt(const camera_fb_t *image)
+// 撮影時刻を Unix time [ms] で返す
+const long long getCapturedAt(const camera_fb_t *image)
 {
-  const auto deltaSec = millis() / 1000 - image->timestamp.tv_sec;
-  return time(NULL) - deltaSec;
+  const auto deltaMSec = millis() - (image->timestamp.tv_sec * 1000LL + image->timestamp.tv_usec / 1000LL);
+  return getCurrentMSec() - deltaMSec;
 }
 
 // 2021-05-29T13-16-07.jpeg のような形式のファイル名を返す
-const String toFilename(time_t unixTime)
+const String toFilename(long long unixTimeMSec)
 {
+  const time_t unixTimeSec = unixTimeMSec / 1000;
   char buffer[32];
-  strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H-%M-%S.jpeg", localtime(&unixTime));
+  strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H-%M-%S.jpeg", localtime(&unixTimeSec));
   return String(buffer);
 }
 


### PR DESCRIPTION
現状の実装だと、前回の撮影時刻を秒単位で保持しているため、撮影タイミングが徐々に遅くなってしまう。

<img width="305" alt="2021-06-09" src="https://user-images.githubusercontent.com/6268183/122240387-b3e2d580-cefc-11eb-968b-662ccd6538a5.png">

1回目の撮影タイミングが `00` 秒であったとしても、24時間経つと `21` 秒あたりになってしまう。

そこで、以下の方法でズレを軽減する。

- 前回の撮影時刻を、秒単位ではなくミリ秒単位で保持する
- ~~撮影完了時ではなく、撮影開始時のタイムスタンプを撮影時刻として使う~~
- 前回の撮影時刻から計算した今回のタイムスタンプを計算して、その値を使う